### PR TITLE
Refactor to use existing resource group variables.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,37 +54,32 @@ variable "subnet_name" {
   default = "postech-fiap-subnet"
 }
 
-resource "azurerm_resource_group" "this" {
-  name     = var.resource_group_name
-  location = var.location
-}
-
 resource "azurerm_virtual_network" "this" {
   name                = var.vnet_name
-  resource_group_name = azurerm_resource_group.this.name
-  location            = azurerm_resource_group.this.location
+  resource_group_name = var.resource_group_name
+  location            = var.location
   address_space       = ["10.0.0.0/16"]
 }
 
 resource "azurerm_subnet" "this" {
   name                 = var.subnet_name
-  resource_group_name  = azurerm_resource_group.this.name
+  resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_public_ip" "this" {
   name                = "${var.appgw_name}-public-ip"
-  resource_group_name = azurerm_resource_group.this.name
-  location            = azurerm_resource_group.this.location
+  resource_group_name = var.resource_group_name
+  location            = var.location
   allocation_method   = "Static"
   sku                 = "Standard"
 }
 
 resource "azurerm_application_gateway" "this" {
   name                = var.appgw_name
-  resource_group_name = azurerm_resource_group.this.name
-  location            = azurerm_resource_group.this.location
+  resource_group_name = var.resource_group_name
+  location            = var.location
 
   sku {
     name     = "WAF_v2"


### PR DESCRIPTION
Replaced hardcoded references to azurerm_resource_group with existing input variables for resource group name and location. This simplifies the configuration and improves reusability and consistency across resources.